### PR TITLE
Follower count check

### DIFF
--- a/src/main/java/frc/lib/io/motor/MotorIO.java
+++ b/src/main/java/frc/lib/io/motor/MotorIO.java
@@ -8,6 +8,10 @@ public abstract class MotorIO {
     private MotorOutputs[] outputs;
 
     protected MotorIO(int numFollowers) {
+        if (numFollowers < 0) {
+            throw new IllegalArgumentException("Number of followers must be non-negative");
+        }
+
         currentSetpoint = new Setpoint(Type.Idle, 0);
         outputs = new MotorOutputs[numFollowers + 1];
         for (int i = 0; i < numFollowers + 1; i++) {

--- a/src/main/java/frc/lib/io/motor/MotorIO.java
+++ b/src/main/java/frc/lib/io/motor/MotorIO.java
@@ -18,9 +18,13 @@ public abstract class MotorIO {
     }
 
     /**
+     * <p>
      * Enables the motor, causing it to take the previously set setpoint
+     * </p>
+     * <p>
      * Note: A setpoint will still be applied, even if the motor is disabled,
      * it just won't take effect until the motor is re-enabled
+     * </p>
      */
     public final void enable() {
         enabled = true;
@@ -28,9 +32,13 @@ public abstract class MotorIO {
     }
 
     /**
+     * <p>
      * Disabled the motor, causing it to idle until re-enabled
+     * </p>
+     * <p>
      * Note: Setpoints will still be applied, but it will only take effect once
      * the motor gets re-enabled
+     * </p>
      */
     public final void disable() {
         enabled = false;
@@ -111,6 +119,7 @@ public abstract class MotorIO {
 
     /**
      * Gets the outputs for the motor
+     * @implNote The first element in the array is where the main motor output is to go
      * @param outputs The array to write the outputs into
      */
     protected abstract void updateOutputs(MotorOutputs[] outputs);


### PR DESCRIPTION
Added a check to the number of followers passed into the MotorIO to ensure it is not negative.
There is technically a case where you could pass in -1 to the number of followers and get a weird state that would not be caught otherwise.